### PR TITLE
[FEATURE] Send a read started state when the user puts the document on the RFID reader

### DIFF
--- a/mrtd/src/main/java/fr/coppernic/lib/interactors/mrtd/MrtdInteractorState.kt
+++ b/mrtd/src/main/java/fr/coppernic/lib/interactors/mrtd/MrtdInteractorState.kt
@@ -1,0 +1,6 @@
+package fr.coppernic.lib.interactors.mrtd
+
+sealed class MrtdInteractorState {
+    object MrtdReadStarted : MrtdInteractorState()
+    data class MrtdReadDone(val dataGroup: DataGroup): MrtdInteractorState()
+}


### PR DESCRIPTION
Create a state class that contains a new state for the document reading: Reading Started and transmit this state when the user puts the document on the RFID reader of the terminal. 
Also convert the single to observable since multiple emissions are now possible from the terminal.

:warning:  This branch should be merged manually after fixing the tree structure of this project